### PR TITLE
Fix error handling for incorrectly formatted docker run commands

### DIFF
--- a/autocompose.sh
+++ b/autocompose.sh
@@ -31,7 +31,10 @@ fi
 echo "Please enter the Docker run command (including \"docker run\"):"
 read docker_run
 
-composerize "$docker_run" 1> "./docker-compose.yml"
+if ! composerize "$docker_run" 1> "./docker-compose.yml"; then
+    echo "Error: The docker run command is incorrectly formatted. Please check the command and try again."
+    exit 1
+fi
 
 echo "Following Compose File has been created:"
 cat docker-compose.yml
@@ -47,4 +50,3 @@ else
 	echo "Script will now exit"
 	exit 0
 fi
-


### PR DESCRIPTION
Fixes #1

Add error handling for incorrectly formatted docker run commands in `autocompose.sh`.

* Add an if statement to check if the `composerize` command fails.
* Display an error message if the `composerize` command fails, informing the user that the docker run command is incorrectly formatted.
* Exit the script gracefully if the `composerize` command fails.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/4rr0wx/autocompose/issues/1?shareId=b91df5cf-225b-4a3f-89e6-0c6415d7dfed).